### PR TITLE
Replaced Neurolinks with Zenodo

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
             <a class="nav-link" href="https://github.com/boutiques/boutiques/blob/master/examples/Getting%20Started%20with%20Boutiques.ipynb">Getting Started</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://brainhack101.github.io/neurolinks">Supported Tools</a>
+            <a class="nav-link" href="https://zenodo.org/">Supported Tools</a>
           </li>
         </ul>
       </div>
@@ -105,10 +105,10 @@
           <p><a class="btn btn-secondary" href="https://github.com/boutiques/boutiques/blob/master/README.md" role="button">View package &raquo;</a></p>
         </div><!-- /.col-lg-4 -->
         <div class="col-lg-4">
-          <img class="rounded-circle" src="https://github.com/brainhack101/neurolinks/blob/master/lynx.png?raw=true" alt="lynx" height="140">
-          <h2>NeuroLinks Repository</h2>
-          <p>As Boutiques has been most heavily adopted in Neuroscience, many descriptors are available through the NeuroLinks resource-sharing portal. <code>bosh publish</code> command enables you to push your descriptor for public consumption, as well.</p>
-          <p><a class="btn btn-secondary" href="https://brainhack101.github.io/neurolinks" role="button">Browse NeuroLinks &raquo;</a></p>
+          <img class="rounded-circle" src="https://about.zenodo.org/static/img/logos/zenodo-black-1000.png" alt="zenodo" height="140">
+          <h2>Zenodo Repository</h2>
+          <p>As Boutiques has been most heavily adopted in Neuroscience, many descriptors are available through the Zenodo resource-sharing portal. <code>bosh publish</code> command enables you to push your descriptor for public consumption, as well.</p>
+          <p><a class="btn btn-secondary" href="https://zenodo.org/" role="button">Browse Zenodo &raquo;</a></p>
         </div><!-- /.col-lg-4 -->
       </div><!-- /.row -->
 

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
             <a class="nav-link" href="https://github.com/boutiques/boutiques/blob/master/examples/Getting%20Started%20with%20Boutiques.ipynb">Getting Started</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://zenodo.org/">Supported Tools</a>
+            <a class="nav-link" href="https://zenodo.org/search?page=1&size=20&keywords=boutiques&keywords=schema&keywords=version&file_type=json&type=software">Supported Tools</a>
           </li>
         </ul>
       </div>
@@ -107,8 +107,8 @@
         <div class="col-lg-4">
           <img class="rounded-circle" src="https://about.zenodo.org/static/img/logos/zenodo-black-1000.png" alt="zenodo" height="140">
           <h2>Zenodo Repository</h2>
-          <p>As Boutiques has been most heavily adopted in Neuroscience, many descriptors are available through the Zenodo resource-sharing portal. <code>bosh publish</code> command enables you to push your descriptor for public consumption, as well.</p>
-          <p><a class="btn btn-secondary" href="https://zenodo.org/" role="button">Browse Zenodo &raquo;</a></p>
+          <p>Many descriptors are available through the Zenodo resource-sharing portal. <code>bosh publish</code> command enables you to push your descriptor for public consumption, as well.</p>
+          <p><a class="btn btn-secondary" href="https://zenodo.org/search?page=1&size=20&keywords=boutiques&keywords=schema&keywords=version&file_type=json&type=software" role="button">Browse Zenodo &raquo;</a></p>
         </div><!-- /.col-lg-4 -->
       </div><!-- /.row -->
 


### PR DESCRIPTION
I replaced the references to Neurolinks with Zenodo.

Changes:
- Link of "Supported Tools"
- Logo
- Zenodo's description + link