### PR TITLE
[Fix] link to Supported Tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
           <img class="rounded-circle" src="https://about.zenodo.org/static/img/logos/zenodo-black-1000.png" alt="zenodo" height="140">
           <h2>Zenodo Repository</h2>
           <p>Many descriptors are available through the Zenodo resource-sharing portal. <code>bosh publish</code> command enables you to push your descriptor for public consumption, as well.</p>
-          <p><a class="btn btn-secondary" href="https://zenodo.org/search?page=1&size=20&keywords=boutiques&keywords=schema&keywords=version&file_type=json&type=software" role="button">Browse Zenodo &raquo;</a></p>
+          <p><a class="btn btn-secondary" href="https://zenodo.org/search?page=1&size=20&keywords=Boutiques&keywords=schema&keywords=version&file_type=json&type=software" role="button">Browse Zenodo &raquo;</a></p>
         </div><!-- /.col-lg-4 -->
       </div><!-- /.row -->
 

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
               <a class="nav-link" href="doc">Docs</a>
             </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://zenodo.org/search?page=1&size=20&keywords=boutiques&keywords=schema&keywords=version&file_type=json&type=software">Supported Tools</a>
+            <a class="nav-link" href="https://zenodo.org/search?page=1&size=20&keywords=Boutiques&keywords=schema&keywords=version&file_type=json&type=software">Supported Tools</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
Seems like the search on Zenodo is case sensitive. I get 0 results with `boutiques`. 